### PR TITLE
Refactor/error handling

### DIFF
--- a/cypress/e2e/home-spec.cy.js
+++ b/cypress/e2e/home-spec.cy.js
@@ -35,10 +35,25 @@ describe('rancid tomatillos homepage user flows', () => {
       .url().should('eq', 'http://localhost:3000/436270')
   })
 
-  it('should display an error message when there is an unsuccessful response', () => {
+  it('should display an error message for 400 error', () => {
+    cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies', {
+      statusCode: 400,
+    })
+    cy.contains('h3', 'Sorry, No movies to display')
+  });
+
+  it('should display an error message for 500 error', () => {
     cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies', {
       statusCode: 500,
     })
     cy.contains('h3', 'Sorry, No movies to display')
   });
+
+  it('should display an error message for 300 response', () => {
+    cy.intercept('GET', 'https://rancid-tomatillos.herokuapp.com/api/v2/movies', {
+      statusCode: 300,
+    })
+    cy.contains('h3', 'Sorry, No movies to display')
+  });
+
 });

--- a/cypress/e2e/single-movie-details-static.cy.js
+++ b/cypress/e2e/single-movie-details-static.cy.js
@@ -62,6 +62,18 @@ describe('should display the right elements in single movie view for Black Adam'
     cy.get('h3')
       .contains('Sorry, movie details could not be loaded')
   })
+
+  it('should handle 400 error', () => {
+    interceptMovie(400, 436270)
+    cy.get('h3')
+      .contains('Sorry, movie details could not be loaded')
+  })
+
+  it('should handle 300 error', () => {
+    interceptMovie(400, 436270)
+    cy.get('h3')
+      .contains('Sorry, movie details could not be loaded')
+  })
 })
 
 
@@ -112,6 +124,18 @@ describe('should display the right elements in single movie view for The Woman K
 
   it('should handle 500 error', () => {
     interceptMovie(500, 724495)
+    cy.get('h3')
+      .contains('Sorry, movie details could not be loaded')
+  })
+
+  it('should handle 400 error', () => {
+    interceptMovie(400, 724495)
+    cy.get('h3')
+      .contains('Sorry, movie details could not be loaded')
+  })
+
+  it('should handle 300 error', () => {
+    interceptMovie(400, 724495)
     cy.get('h3')
       .contains('Sorry, movie details could not be loaded')
   })

--- a/src/apiCalls/apiCalls.js
+++ b/src/apiCalls/apiCalls.js
@@ -1,10 +1,9 @@
 const getData = (data) => {
   return fetch(`https://rancid-tomatillos.herokuapp.com/api/v2/${data}`)
     .then(response => {
-      if (response.status === 500) {
-        return 'serverError'
-      }
-      if (response.status === 200) {
+      if (!response.ok) {
+        throw new Error(`${response.status} error`)
+      } else {
         return response.json()
       }
     })

--- a/src/components/AllMovies/AllMovies.js
+++ b/src/components/AllMovies/AllMovies.js
@@ -24,6 +24,7 @@ const AllMovies = ({  waitingForFetch, serverError, movies, changeSearch, search
   const ErrorMessage = () => {
     return (<h3 className='error-message' id='error-message'>Sorry, No movies to display</h3>);
   }
+  
   return (
     <section className='all-movies-view'>
       {waitingForFetch && <Loader />}

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -25,13 +25,11 @@ const App = () => {
           setAllMovies(data.movies);
           setWaitingForFetch(false);
         } else {
-          console.log('then')
           setServerError(true);
           setWaitingForFetch(false);
         }
       })
       .catch((err) => {
-        console.log("catch")
         console.error(err);
         setServerError(true);
         setWaitingForFetch(false);

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -20,14 +20,21 @@ const App = () => {
   useEffect(() => {
     getData('movies')
       .then(data => {
-        if (checkServerError(data)) {
-          setServerError(true);
-          setWaitingForFetch(false);
-        } else {
+        if (data.movies) {
           setMovies(data.movies);
           setAllMovies(data.movies);
           setWaitingForFetch(false);
+        } else {
+          console.log('then')
+          setServerError(true);
+          setWaitingForFetch(false);
         }
+      })
+      .catch((err) => {
+        console.log("catch")
+        console.error(err);
+        setServerError(true);
+        setWaitingForFetch(false);
       })
   }, [])
 

--- a/src/components/MovieDetails/MovieDetails.js
+++ b/src/components/MovieDetails/MovieDetails.js
@@ -18,14 +18,19 @@ const MovieDetails = ({ goToHomeView, getData }) => {
     
     getData(`movies/${chosenID}`)
       .then(data => {
-        if (checkServerError(data)) {
-          setServerError(true)
-          setWaitingForSingleFetch(false)
-        } else {
+        if (data.movie) {
           const fetchedMovie = data.movie
           setDetails(fetchedMovie);
           setWaitingForSingleFetch(false)
+        } else {
+          setServerError(true);
+          setWaitingForSingleFetch(false);
         }
+      })
+      .catch((err) => {
+        console.error(err);
+        setServerError(true);
+        setWaitingForSingleFetch(false);
       })
   }, [])
 


### PR DESCRIPTION
#### What is the feature?
- Refactor error handling to throw new Error and refer to a catch block instead of a .then block

#### How you implemented the solution?
- Refactor the function in the api call to throw new error instead of returning a message that our 'checkServerError' checks for.
- I added cypress tests for all status codes. 

#### Any changes in the UI (Screenshots)?
- no

#### How to test the feature (A test scenario or any new setup)?
- Please run cypress tests and see all are passing.

